### PR TITLE
About SET foreign_key_checks = 0

### DIFF
--- a/lib/secondbase/tasks.rb
+++ b/lib/secondbase/tasks.rb
@@ -161,7 +161,7 @@ namespace :db do
 
         # now lets clone the structure for secondbase
         use_secondbase('test')
-        ActiveRecord::Base.connection.execute('SET foreign_key_checks = 0')
+        ActiveRecord::Base.connection.execute('SET foreign_key_checks = 0') if secondbase_config(RAILS_ENV)['adapter'][/mysql/]
         IO.readlines("#{RAILS_ROOT}/db/#{SecondBase::CONNECTION_PREFIX}_#{RAILS_ENV}_structure.sql").join.split("\n\n").each do |table|
           ActiveRecord::Base.connection.execute(table)
         end


### PR DESCRIPTION
Hey Karle,

Thanks so much for your great gem, it saved me a lot of time.

When I am using sqlite3 as my second database, I came across this error:

SQLite3::SQLException: near "SET": syntax error: SET foreign_key_checks = 0

So I did a quick fix so it won't fail on me.

Thanks again,
Libin
