### PR TITLE
get rid of returning operator

### DIFF
--- a/lib/generators/secondbase/migration_generator.rb
+++ b/lib/generators/secondbase/migration_generator.rb
@@ -29,9 +29,7 @@ module Secondbase
     private 
     # TODO: We need to add support for name/value pairs like title:string dob:date etc..
     def get_local_assigns
-      returning(assigns = {}) do
-        assigns[:class_name] = class_name
-      end
+      { :class_name => class_name }
     end
         
   end


### PR DESCRIPTION
since rails 3.1 we have no `returning`
